### PR TITLE
Update to qiskit-qir 0.4

### DIFF
--- a/azure-quantum/requirements-qiskit.txt
+++ b/azure-quantum/requirements-qiskit.txt
@@ -1,6 +1,6 @@
 qiskit-ionq>=0.3.3,<1.0
 # TODO(kuzminrobin, #494): See line below. Upon fix of #494 consider reverting fragment `<0.25.0` back to `<1.0`.
 qiskit-terra>=0.19.1,<0.25.0
-qiskit-qir>=0.3.1,<0.4
+qiskit-qir>=0.4,<0.5
 Markdown>=3.4.1,<4.0
 python-markdown-math>=0.8.0,<1.0


### PR DESCRIPTION
This PR updates the requirements for qiskit-qir to `>=0.4,<0.5` which transitively updates to pyqir `>=0.10,<0.11` which has bug fixes for base profile QIR code generation. The output QIR will change for any consumers to use the correct results and qubits attributes on entry points.