### PR TITLE
Remove QIO related references and fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ pip install azure-quantum[cirq]
 pip install azure-quantum[qsharp]
 ```
 
-To get started and submit your first job, see the official [Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit-portal?pivots=platform-ionq).
+To get started, visit the following Quickstart guides:
+
+- [Quickstart: Submit a circuit with Qiskit](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
+- [Quickstart: Submit a circuit with Cirq](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
+- [Quickstart: Submit a circuit with a provider-specific format](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-provider-format).
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://learn.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,11 +6,6 @@ This project uses GitHub Issues to track bugs and feature requests. Please searc
 issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
 feature request as a new Issue.
 
-If you have feedback about some other part of the Microsoft Quantum Development Kit,
-please see the [contribution guide](https://docs.microsoft.com/azure/quantum/contributing-overview/)
-for more information.
-
-
 ## Microsoft Support Policy  
 
 Support for this **PROJECT or PRODUCT** is limited to the resources listed above.

--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -4,10 +4,9 @@
 
 [![Build Status](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_apis/build/status/microsoft.qdk-python?branchName=main)](https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/latest?definitionId=32&branchName=main) [![PyPI version](https://badge.fury.io/py/azure-quantum.svg)](https://badge.fury.io/py/azure-quantum)
 
-Azure Quantum is Microsoft's cloud service for running Quantum Computing circuits or solving Optimization problems with our quantum partners and technologies. The `azure-quantum` package for Python provides functionality for interacting with Azure Quantum workspaces,
-including creating jobs, listing jobs, and retrieving job results. For more information, view the [Azure Quantum Documentation](https://docs.microsoft.com/azure/quantum).
+Azure Quantum is Microsoft's cloud service for running Quantum Computing programs and circuits with our quantum partners and technologies. The `azure-quantum` package for Python provides functionality for interacting with Azure Quantum workspaces, including creating jobs, listing jobs, and retrieving job results. For more information, view the [Azure Quantum Documentation](https://learn.microsoft.com/en-us/azure/quantum/).
 
-This package supports submitting quantum circuits or problem definitions written with Python. To submit quantum programs written with Q#, Microsoft's Domain-specific language for Quantum Programming, view [Submit Q# Jobs to Azure Quantum](https://docs.microsoft.com/azure/quantum/how-to-submit-jobs).
+This package supports submitting quantum circuits or problem definitions written with Python. To submit quantum programs written with Q#, Microsoft's Domain-specific language for Quantum Programming, view [Submit Q# Jobs to Azure Quantum](https://learn.microsoft.com/azure/quantum/how-to-submit-jobs).
 
 ## Installation ##
 
@@ -31,13 +30,13 @@ pip install azure-quantum[cirq]
 
 ## Getting started and Quickstart guides ##
 
-To work in Azure Quantum, you need an Azure subscription. If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/). Follow the [Create an Azure Quantum workspace](https://docs.microsoft.com/azure/quantum/how-to-create-workspace) how-to guide to set up your Workspace and enable your preferred providers.
+To work in Azure Quantum, you need an Azure subscription. If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/). Follow the [Create an Azure Quantum workspace](https://learn.microsoft.com/azure/quantum/how-to-create-workspace) how-to guide to set up your Workspace and enable your preferred providers.
 
 To get started, visit the following Quickstart guides:
 
-- [Quickstart: Submit a circuit with Qiskit](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
-- [Quickstart: Submit a circuit with Cirq](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
-- [Quickstart: Submit a circuit with a provider-specific format](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-provider-format).
+- [Quickstart: Submit a circuit with Qiskit](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
+- [Quickstart: Submit a circuit with Cirq](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit)
+- [Quickstart: Submit a circuit with a provider-specific format](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-provider-format).
 
 ## General usage ##
 
@@ -61,16 +60,16 @@ To list all targets that are available to your workspace, run
 workspace.get_targets()
 ```
 
-### Submit a quantum circuit or optimization problem ###
+### Submit a quantum program or circuit ###
 
-First, define a quantum circuit or optimization problem, and create a job by submitting it to one of the available targets:
+First, define a quantum program or circuit, and create a job by submitting it to one of the available targets:
 
 ```python
 # Enter target name below
-target = workspace.get_targets("")
+target = workspace.get_targets("mytarget")
 
-# Submit quantum circuit or optimization problem
-job = target.submit(problem)
+# Submit quantum program or circuit
+job = target.submit(my_quantum_problem)
 
 # Wait for job to complete and fetch results
 result = job.get_results()

--- a/azure-quantum/azure/quantum/workspace.py
+++ b/azure-quantum/azure/quantum/workspace.py
@@ -111,7 +111,7 @@ class Workspace:
 
     :param credential:
         The credential to use to connect to Azure services.
-        Normally one of the credential types from Azure.Identity (https://docs.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes).
+        Normally one of the credential types from Azure.Identity (https://learn.microsoft.com/python/api/overview/azure/identity-readme?view=azure-python#credential-classes).
 
         Defaults to \"DefaultAzureCredential\", which will attempt multiple 
         forms of authentication.

--- a/azure-quantum/examples/resource_estimation/README.md
+++ b/azure-quantum/examples/resource_estimation/README.md
@@ -6,7 +6,7 @@ Quantum Resource Estimator through the `azure-quantum` Python API.
 ## Prerequisites
 
 These scripts require access to an Azure Quantum workspace.  Read [our
-documentation](https://learn.microsoft.com/azure/quantum/how-to-create-workspace?tabs=payg%2Ctabid-quick)
+documentation](https://learn.microsoft.com/azure/quantum/how-to-create-workspace)
 to learn how to set up an Azure Quantum workspace.  Once the Azure Quantum
 workspace is created, you can retrieve the _resource id_ and _location_ from
 the _Overview_ page of your workspace.

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -1,7 +1,3 @@
-#!/bin/env python
-# -*- coding: utf-8 -*-
-##
-# test_workspace.py: Checks correctness of azure.quantum.optimization module.
 ##
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.

--- a/samples/hello-world/HW-ionq-cirq.ipynb
+++ b/samples/hello-world/HW-ionq-cirq.ipynb
@@ -125,7 +125,7 @@
     "| Aria 1 | `ionq.qpu.aria-1` | 23 qubits | IonQ's Aria 1 trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
     "| Quantum computer | `ionq.qpu` | 11 qubits | IonQ's trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
     "\n",
-    "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://docs.microsoft.com/azure/quantum/provider-ionq)."
+    "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://learn.microsoft.com/azure/quantum/provider-ionq)."
    ]
   },
   {
@@ -197,7 +197,7 @@
     }
    },
    "source": [
-    "The job ID can be used to retrieve the results later using the [get_details function](https://docs.microsoft.com/azure/quantum/optimization-job-reference#jobdetails) or by viewing it under the **Job management** section of the portal."
+    "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
    ]
   },
   {
@@ -313,7 +313,7 @@
     "### 6. Next steps\n",
     "Next, you can try running a program on IonQ's hardware target. Just replace `ionq.simulator` with `ionq.qpu`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
     "\n",
-    "To learn more about submitting Cirq circuits to Azure Quantum, review [this documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-cirq?pivots=platform-ionq).\n",
+    "To learn more about submitting Cirq circuits to Azure Quantum, review [this documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-cirq?tabs=tabid-ionq).\n",
     "\n",
     "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
    ]

--- a/samples/hello-world/HW-ionq-qiskit.ipynb
+++ b/samples/hello-world/HW-ionq-qiskit.ipynb
@@ -129,7 +129,7 @@
     "| Aria 1 | `ionq.qpu.aria-1` | 23 qubits | IonQ's Aria 1 trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
     "| Quantum computer | `ionq.qpu` | 11 qubits | IonQ's trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
     "\n",
-    "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://docs.microsoft.com/azure/quantum/provider-ionq)."
+    "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://learn.microsoft.com/azure/quantum/provider-ionq)."
    ]
   },
   {
@@ -205,7 +205,7 @@
     }
    },
    "source": [
-    "The job ID can be used to retrieve the results later using the [get_details function](https://docs.microsoft.com/azure/quantum/optimization-job-reference#jobdetails) or by viewing it under the **Job management** section of the portal."
+    "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
    ]
   },
   {
@@ -284,9 +284,9 @@
     "### 6. Next steps\n",
     "Next, you can try running a program on IonQ's hardware target. Just replace `ionq.simulator` with `ionq.qpu`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
     "\n",
-    "To learn more about submitting Qiskit circuits to Azure Quantum, review [this documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?pivots=platform-ionq).\n",
+    "To learn more about submitting Qiskit circuits to Azure Quantum, review [this documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?tabs=tabid-ionq).\n",
     "\n",
-    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
    ]
   }
  ],

--- a/samples/hello-world/HW-ionq-qsharp.ipynb
+++ b/samples/hello-world/HW-ionq-qsharp.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# 👋🌍 Hello, world: Submit a Q# job to IonQ\n",
         "\n",
-        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [IonQ](https://ionq.com/). We will use [Q#](https://docs.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
+        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [IonQ](https://ionq.com/). We will use [Q#](https://learn.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
       ]
     },
     {
@@ -130,7 +130,7 @@
         "| Aria 1 | `ionq.qpu.aria-1` | 23 qubits | IonQ's Aria 1 trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
         "| Quantum computer | `ionq.qpu` | 11 qubits | IonQ's trapped-ion quantum computer. This is real quantum hardware, not a simulation. |\n",
         "\n",
-        "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://docs.microsoft.com/azure/quantum/provider-ionq)."
+        "For this example, we will use `ionq.simulator`. To learn more about IonQ's targets, check out our [documentation](https://learn.microsoft.com/azure/quantum/provider-ionq)."
       ]
     },
     {
@@ -264,7 +264,7 @@
         }
       },
       "source": [
-        "The job ID can be used to retrieve the results later using the `workspace.get_job` function or by viewing it under the **Job management** section of the portal."
+        "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
       ]
     },
     {
@@ -337,9 +337,9 @@
         "### 5. Next steps\n",
         "Next, you can try running a program on IonQ's hardware target - just replace `ionq.simulator` with `ionq.qpu`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
         "\n",
-        "To learn more about submitting jobs to Azure Quantum using Q#, refer to [this documentation](https://docs.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python).\n",
+        "To learn more about submitting jobs to Azure Quantum using Q#, refer to [this documentation](https://learn.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python).\n",
         "\n",
-        "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/hello-world/HW-quantinuum-cirq.ipynb
+++ b/samples/hello-world/HW-quantinuum-cirq.ipynb
@@ -208,7 +208,7 @@
     }
    },
    "source": [
-    "The job ID can be used to retrieve the results later using the `get_job` function or by viewing it under the **Job management** section of the portal."
+    "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
    ]
   },
   {
@@ -299,9 +299,9 @@
     "### 6. Next steps\n",
     "Next, you can try running a program on Quantinuum's emulation and hardware targets. Just replace `quantinuum.sim.h1-1sc` with `quantinuum.sim.h1-1e` or `quantinuum.qpu.h1-1`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
     "\n",
-    "To learn more about submitting Cirq circuits to Azure Quantum, review [this documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-cirq?pivots=platform-quantinuum).\n",
+    "To learn more about submitting Cirq circuits to Azure Quantum, review [this documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-cirq?tabs=tabid-quantinuum).\n",
     "\n",
-    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
    ]
   }
  ],

--- a/samples/hello-world/HW-quantinuum-qiskit.ipynb
+++ b/samples/hello-world/HW-quantinuum-qiskit.ipynb
@@ -253,7 +253,7 @@
     }
    },
    "source": [
-    "The job ID can be used to retrieve the results later using the [get_details function](https://docs.microsoft.com/azure/quantum/optimization-job-reference#jobdetails) or by viewing it under the **Job management** section of the portal."
+    "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
    ]
   },
   {
@@ -367,9 +367,9 @@
     "### 6. Next steps\n",
     "Next, you can try running a program on Quantinuum's H1-1 emulation and hardware targets. Just replace `quantinuum.sim.h1-1sc` with `quantinuum.sim.h1-1e` or `quantinuum.qpu.h1-1`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
     "\n",
-    "To learn more about submitting Qiskit circuits to Azure Quantum, review [this documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?pivots=platform-quantinuum).\n",
+    "To learn more about submitting Qiskit circuits to Azure Quantum, review [this documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit&tabs=tabid-quantinuum).\n",
     "\n",
-    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+    "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
    ]
   }
  ],

--- a/samples/hello-world/HW-quantinuum-qsharp.ipynb
+++ b/samples/hello-world/HW-quantinuum-qsharp.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# 👋🌍 Hello, world: Submit a Q# job to Quantinuum\n",
         "\n",
-        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [Quantinuum](https://www.quantinuum.com/). We will use [Q#](https://docs.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
+        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [Quantinuum](https://www.quantinuum.com/). We will use [Q#](https://learn.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
       ]
     },
     {
@@ -275,7 +275,7 @@
         }
       },
       "source": [
-        "The job ID can be used to retrieve the results later using the `workspace.get_job` function or by viewing it under the **Job management** section of the portal."
+        "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
       ]
     },
     {
@@ -348,9 +348,9 @@
         "### 5. Next steps\n",
         "Next, you can try running a program on Quantinuum's emulation target - just replace `quantinuum.sim.h1-1sc` with `quantinuum.sim.h1-1e`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
         "\n",
-        "To learn more about submitting jobs to Azure Quantum using Q#, refer to [this documentation](https://docs.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python).\n",
+        "To learn more about submitting jobs to Azure Quantum using Q#, refer to [this documentation](https://learn.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python&tabs=tabid-python).\n",
         "\n",
-        "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, review the [Azure Quantum documentation on job costs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/hello-world/HW-rigetti-qiskit.ipynb
+++ b/samples/hello-world/HW-rigetti-qiskit.ipynb
@@ -138,7 +138,7 @@
         "| Ankaa-9q-1 (hardware) | `rigetti.qpu.ankaa-9q-1` | 9 qubits | A 4th-generation, square-lattice processor. Pricing based on QPUs. |\n",
         "| Ankaa-2 (hardware) | `rigetti.qpu.ankaa-2` | 84 qubits | A 4th-generation, square-lattice processor. Pricing based on QPUs. |\n",
         "\n",
-        "For this example, we will use `rigetti.sim.qvm`. To learn more about Rigetti's targets, check out [Rigetti's Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/provider-rigetti)."
+        "For this example, we will use `rigetti.sim.qvm`. To learn more about Rigetti's targets, check out [Rigetti's Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/provider-rigetti)."
       ]
     },
     {
@@ -261,7 +261,7 @@
         }
       },
       "source": [
-        "The job ID can be used to retrieve the results later using the [`get_job` method](https://learn.microsoft.com/azure/quantum/optimization-workspace#workspaceget_job) or by viewing it under the **Job management** section of the portal."
+        "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
       ]
     },
     {
@@ -349,9 +349,9 @@
         "### 5. Next steps\n",
         "Next, you can try running a program on one of Rigetti's hardware targets. Just replace `RigettiTarget.QVM` with `RigettiTarget.ANKAA_9Q_1`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
         "\n",
-        "To learn more about submitting Qiskit circuits to Azure Quantum, review the Qiskit section of the [Azure Quantum documentation's page on Qiskit jobs](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?pivots=platform-rigetti).\n",
+        "To learn more about submitting Qiskit circuits to Azure Quantum, review the Qiskit section of the [Azure Quantum documentation's page on Qiskit jobs](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit&tabs=tabid-rigetti).\n",
         "\n",
-        "To learn more about job pricing, review the [Azure Quantum documentation's pricing page](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, review the [Azure Quantum documentation's pricing page](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/hello-world/HW-rigetti-qsharp.ipynb
+++ b/samples/hello-world/HW-rigetti-qsharp.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# 👋🌍 Hello, world: Submit a Q# job to Rigetti\n",
         "\n",
-        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [Rigetti](https://www.rigetti.com/). We will use [Q#](https://docs.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
+        "In this notebook, we'll review the basics of Azure Quantum by submitting a simple *job*, or quantum program, to [Rigetti](https://www.rigetti.com/). We will use [Q#](https://learn.microsoft.com/azure/quantum/user-guide/) to express the quantum job."
       ]
     },
     {
@@ -131,7 +131,7 @@
         "| Ankaa-9q-1 (hardware) | `rigetti.qpu.ankaa-9q-1` | 9 qubits | A 4th-generation, square-lattice processor. Pricing based on QPUs. |\n",
         "| Ankaa-2 (hardware) | `rigetti.qpu.ankaa-2` | 84 qubits | A 4th-generation, square-lattice processor. Pricing based on QPUs. |\n",
         "\n",
-        "For this example, we will use `rigetti.sim.qvm`. To learn more about Rigetti's targets, check out [Rigetti's Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/provider-rigetti)."
+        "For this example, we will use `rigetti.sim.qvm`. To learn more about Rigetti's targets, check out [Rigetti's Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/provider-rigetti)."
       ]
     },
     {
@@ -266,7 +266,7 @@
         }
       },
       "source": [
-        "The job ID can be used to retrieve the results later using the `workspace.get_job` function or by viewing it under the **Job management** section of the portal."
+        "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal."
       ]
     },
     {
@@ -340,9 +340,9 @@
         "### 5. Next steps\n",
         "Next, you can try running a program on one of Rigetti's hardware targets. Just replace `rigetti.sim.qvm` with `rigetti.qpu.ankaa-9q-1`. Or try another sample by navigating back to the sample gallery. The same \"hello world\" sample can be run with different quantum providers by choosing another option in the gallery card drop-down menu. Don't worry - your work here is automatically saved.\n",
         "\n",
-        "To learn more about submitting jobs to Azure Quantum using Q#, refer to the [Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python).\n",
+        "To learn more about submitting jobs to Azure Quantum using Q#, refer to the [Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/how-to-submit-jobs?pivots=ide-python&tabs=tabid-python).\n",
         "\n",
-        "To learn more about job pricing, review [Azure Quantum's pricing documentation](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, review [Azure Quantum's pricing documentation](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/hello-world/README.md
+++ b/samples/hello-world/README.md
@@ -15,7 +15,7 @@ products:
 
 These are Azure Quantum sample notebooks that illustrate how to use Q#, Qiskit, or Cirq to write a simple program and run it against an Azure Quantum provider.
 
-These samples are available as part of the notebook samples gallery in Azure Quantum workspaces in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://docs.microsoft.com/azure/quantum/get-started-jupyter-notebook?tabs=tabid-ionq).
+These samples are available as part of the notebook samples gallery in Azure Quantum workspaces in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://learn.microsoft.com/azure/quantum/get-started-jupyter-notebook).
 
 ## Manifest
 

--- a/samples/hidden-shift/README.md
+++ b/samples/hidden-shift/README.md
@@ -15,7 +15,7 @@ products:
 
 This sample demonstrates how to use Qiskit and Azure Quantum together to learn the hidden shift of bent functions.
 
-This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://docs.microsoft.com/azure/quantum/get-started-jupyter-notebook?tabs=tabid-ionq).
+This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://learn.microsoft.com/azure/quantum/get-started-jupyter-notebook).
 
 ## Manifest
 

--- a/samples/hidden-shift/hidden-shift.ipynb
+++ b/samples/hidden-shift/hidden-shift.ipynb
@@ -7,7 +7,7 @@
         "# Quantum algorithms for fast convolutions and hidden shifts\n",
         "\n",
         "Welcome, this notebook explores the execution of _hidden shift problems_ on a quantum computer.\n",
-        "This notebook does assume some quantum knowledge.  We invite you to have a look into our 👋🌎 _Hello world_ samples in the notebook gallery and the [Quantum Katas](https://docs.microsoft.com/azure/quantum/tutorial-qdk-intro-to-katas) for introductory content on quantum computing.\n",
+        "This notebook does assume some quantum knowledge.  We invite you to have a look into our 👋🌎 _Hello world_ samples in the notebook gallery and the [Quantum Katas](https://learn.microsoft.com/azure/quantum/tutorial-qdk-intro-to-katas) for introductory content on quantum computing.\n",
         "\n",
         "One way to think about the space of hidden shift problems\n",
         "is that we are using the quantum computer to help us compute the convolution of two functions. \n",
@@ -468,7 +468,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "The job ID can be used to retrieve the results later using the [`get_job` method](https://learn.microsoft.com/azure/quantum/optimization-workspace#workspaceget_job) or by viewing it under the **Job management** section of the portal.\n",
+        "The job ID can be used to retrieve the results later using the [get_job method](https://learn.microsoft.com/python/azure-quantum/azure.quantum.workspace?#azure-quantum-workspace-get-job) or by viewing it under the **Job management** section of the portal.\n",
         "\n",
         "You can monitor the job status with Qiskit's `job_monitor` function.\n",
         "\n",
@@ -515,7 +515,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Now we'll create a backend for Quantinuum's noisy simulator.  Before we running the circuit, we are going to estimate the cost of simulating the circuit (To learn more about job pricing, review [the Azure Quantum docs](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs).)."
+        "Now we'll create a backend for Quantinuum's noisy simulator.  Before we running the circuit, we are going to estimate the cost of simulating the circuit (To learn more about job pricing, review [the Azure Quantum docs](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs).)."
       ]
     },
     {
@@ -1052,11 +1052,11 @@
         "* Configuring different hidden shift problems based on the provided helper circuits\n",
         "* Trying out different backends: How would the 3D-bar plot look like when running on a real QPU? Just replace `ionq.simulator` by `ionq.qpu`.\n",
         "* Implementing new phase oracles for bent functions: What about Maiorana-McFarland bent functions in which $h \\neq 0$ or $\\pi$ is not an index permutation?\n",
-        "* Try this [Hidden Shift sample using Q# standalone](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum/hidden-shift#finding-hidden-shift-of-bent-functions-using-the-azure-quantum-service), or create a [python host program](https://docs.microsoft.com/azure/quantum/user-guide/host-programs?tabs=tabid-python#q-with-host-programs) to run the Q# sample using python.\n",
+        "* Try this [Hidden Shift sample using Q# standalone](https://github.com/microsoft/Quantum/tree/main/samples/azure-quantum/hidden-shift#finding-hidden-shift-of-bent-functions-using-the-azure-quantum-service), or create a [python host program](https://learn.microsoft.com/azure/quantum/user-guide/host-programs?tabs=tabid-python#q-with-host-programs) to run the Q# sample using python.\n",
         "\n",
-        "To learn more about submitting Qiskit circuits to Azure Quantum, review [the Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?pivots=platform-ionq).\n",
+        "To learn more about submitting Qiskit circuits to Azure Quantum, review [the Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit).\n",
         "\n",
-        "To learn more about job pricing, also review [the Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, also review [the Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/quantum-signal-processing/README.md
+++ b/samples/quantum-signal-processing/README.md
@@ -14,7 +14,7 @@ products:
 
 This is an Azure Quantum sample illustrates how to evaluate polynomials using Qiskit, a single qubit, and quantum signal processing.
 
-This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://docs.microsoft.com/azure/quantum/get-started-jupyter-notebook?tabs=tabid-ionq).
+This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://learn.microsoft.com/azure/quantum/get-started-jupyter-notebook).
 
 ## Manifest
 

--- a/samples/quantum-signal-processing/signal-processing.ipynb
+++ b/samples/quantum-signal-processing/signal-processing.ipynb
@@ -674,9 +674,9 @@
         "* Changing the number of discretization points and number of shots to increase or decrease the precision of the plots.\n",
         "* Trying out different backends: How would the 3D-bar plot look like when running on a real QPU? Just replace `ionq.simulator` by `ionq.qpu`.\n",
         "\n",
-        "To learn more about submitting Qiskit circuits to Azure Quantum, review [the Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/quickstart-microsoft-qiskit?pivots=platform-ionq).\n",
+        "To learn more about submitting Qiskit circuits to Azure Quantum, review [the Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/quickstart-microsoft-qiskit).\n",
         "\n",
-        "To learn more about job pricing, also review [the Azure Quantum documentation](https://docs.microsoft.com/azure/quantum/azure-quantum-job-costs)."
+        "To learn more about job pricing, also review [the Azure Quantum documentation](https://learn.microsoft.com/azure/quantum/azure-quantum-job-costs)."
       ]
     }
   ],

--- a/samples/resource-estimator/estimation-chemistry.ipynb
+++ b/samples/resource-estimator/estimation-chemistry.ipynb
@@ -110,8 +110,8 @@
     "| https://aka.ms/fcidump/n2-10e-8o             | n2-10e-8o             | 10 electron, 8 orbital active space of he dissociated nitrogen at 3 Angstrom distance                                                                                                                     |\n",
     "\n",
     "You can also pass your own FCIDUMP files via \n",
-    "* [raw links to files in Github](https://docs.github.com/repositories/working-with-files/using-files/viewing-a-file#viewing-or-copying-the-raw-file-content) repositories (see how to [add files to Github repositories](https://docs.github.com/repositories/working-with-files/managing-files/creating-new-files))\n",
-    "* [files on Github gists](https://docs.github.com/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists)\n",
+    "* [raw links to files in Github](https://learn.github.com/repositories/working-with-files/using-files/viewing-a-file#viewing-or-copying-the-raw-file-content) repositories (see how to [add files to Github repositories](https://learn.github.com/repositories/working-with-files/managing-files/creating-new-files))\n",
+    "* [files on Github gists](https://learn.github.com/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists)\n",
     "* [files in Azure Blob Storage](https://learn.microsoft.com/azure/storage/blobs/storage-blobs-introduction) using [SAS tokens](https://learn.microsoft.com/azure/cognitive-services/translator/document-translation/how-to-guides/create-sas-tokens?tabs=Containers#create-sas-tokens-in-the-azure-portal)\n",
     "\n",
     "The URI is passed to the parameters as so called file URI with the name `\"fcidumpUri\"`:"

--- a/samples/sessions/README.md
+++ b/samples/sessions/README.md
@@ -11,7 +11,7 @@ products:
 
 This sample shows you how to work with sessions in Azure Quantum by using a session to run multiple Qiskit jobs.
 
-This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://docs.microsoft.com/azure/quantum/get-started-jupyter-notebook?tabs=tabid-ionq).
+This sample is available as part of the Azure Quantum notebook samples gallery in the Azure Portal. For an example of how to run these notebooks in Azure, see [this getting started guide](https://learn.microsoft.com/azure/quantum/get-started-jupyter-notebook).
 
 ## Manifest
 


### PR DESCRIPTION
## Changes

- Removed references from QIO-related optimization in code documentation, readmes, and Jupyter Notebooks.
- Updated documentation links using the new "learn.microsoft.com" URL instead of "docs.microsoft.com".
- Fixed links that were pointing to old/non-existing documentation and methods (`get_details` function does not exist and `Workspace.get_job` method is the new way).
- Fixed links that were provider specific, either by using the correct provider-specific query-strings or removing query-strings for cases where it shouldn't be provider specific

## Tests

I manually checked all these links in an "in-private" browser session.