### PR TITLE
fix: @pytest.mark attributes + prep for 1.1 release

### DIFF
--- a/azure-quantum/README.md
+++ b/azure-quantum/README.md
@@ -69,7 +69,7 @@ First, define a quantum program or circuit, and create a job by submitting it to
 target = workspace.get_targets("mytarget")
 
 # Submit quantum program or circuit
-job = target.submit(my_quantum_problem)
+job = target.submit(my_quantum_program)
 
 # Wait for job to complete and fetch results
 result = job.get_results()

--- a/azure-quantum/pytest.ini
+++ b/azure-quantum/pytest.ini
@@ -3,11 +3,6 @@ asyncio_mode = auto
 markers =
     live_test: mark a test as a live test that requires recordings. 
     ionq: mark a test as requiring access to ionq.
-    oneqbit: mark a test as requiring access to 1qbit.
-    asyncio: mark a test as using async i/o.
-    toshiba: mark a test as requiring access to toshiba.
-    qio: mark a test as requiring access to qio targets.
-    fpga: mark a test as requiring access to fpga targets.
     quantinuum: mark a test as requiring access to quantinuum.
     rigetti: mark a test as requiring access to Rigetti targets.
     qci: mark a test as requiring access to QCI targets.
@@ -16,6 +11,7 @@ markers =
     session: mark a test as requiring access to session feature.
     cirq: mark a test as requiring Cirq
     qiskit: mark a test as requiring Qiskit
-    quil: mark a test as requiring Quil
     qir: mark a test as requiring QIR 
     echo_targets: mark a test as requiring access to Microsoft test echo targets.
+    pasqal:  mark a test as requiring access to Pasqal targets.
+    microsoft_elements_dft: mark a test as requiring access to microsoft.dft targets.

--- a/set_version.py
+++ b/set_version.py
@@ -5,7 +5,7 @@
 
 import os
 
-major_minor = "1.0"
+major_minor = "1.1"
 
 BUILD_TYPE = os.environ.get("BUILD_TYPE") or "dev"
 PATCH_NUMBER = os.environ.get("PATCH_NUMBER") or "0"


### PR DESCRIPTION
- removed deprecated `@pytest.mark` attributes and added missing ones
- bump to `1.1.*` version in `set_version.py` in prep for `1.1.0` release