### PR TITLE
fix: document JobFailedWithResultsError

### DIFF
--- a/azure-quantum/azure/quantum/job/__init__.py
+++ b/azure-quantum/azure/quantum/job/__init__.py
@@ -24,5 +24,6 @@ __all__ = [
     "SessionHost",
     "SessionDetails",
     "SessionStatus",
-    "SessionJobFailurePolicy"
+    "SessionJobFailurePolicy",
+    "JobFailedWithResultsError"
     ]

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -109,7 +109,7 @@ class Job(BaseJob, FilteredJob):
         Raises :class:`RuntimeError` if job execution fails.
         
         Raises :class:`azure.quantum.job.JobFailedWithResultsError` if job execution fails, 
-                but intermediate results could still be retrieved (e.g. for jobs submitted against "microsoft.dft" target).
+                but failure results could still be retrieved (e.g. for jobs submitted against "microsoft.dft" target).
 
         :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: float

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -107,8 +107,9 @@ class Job(BaseJob, FilteredJob):
         storage container linked via the workspace.
         
         Raises :class:`RuntimeError` if job execution fails.
+        
         Raises :class:`azure.quantum.job.JobFailedWithResultsError` if job execution fails, 
-        but intermediate results could still be retrieved (e.g. for jobs submitted against "microsoft.dft" target).
+                but intermediate results could still be retrieved (e.g. for jobs submitted against "microsoft.dft" target).
 
         :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: float

--- a/azure-quantum/azure/quantum/job/job.py
+++ b/azure-quantum/azure/quantum/job/job.py
@@ -105,8 +105,10 @@ class Job(BaseJob, FilteredJob):
     def get_results(self, timeout_secs: float = DEFAULT_TIMEOUT):
         """Get job results by downloading the results blob from the
         storage container linked via the workspace.
-
+        
         Raises :class:`RuntimeError` if job execution fails.
+        Raises :class:`azure.quantum.job.JobFailedWithResultsError` if job execution fails, 
+        but intermediate results could still be retrieved (e.g. for jobs submitted against "microsoft.dft" target).
 
         :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: float

--- a/azure-quantum/azure/quantum/job/job_failed_with_results_error.py
+++ b/azure-quantum/azure/quantum/job/job_failed_with_results_error.py
@@ -2,14 +2,22 @@ import json
 from typing import Any, Dict, Union
 
 class JobFailedWithResultsError(RuntimeError):
-    """
-    Error produced when Job completes with status "Failed" and the Job
+    """Error produced when Job completes with status "Failed" and the Job
     supports producing failure results.
 
-    The failure results can be accessed with get_failure_results() method
+    The failure results can be accessed with get_failure_results() method.
     """
-    
+
     def __init__(self, message: str, failure_results: Any, *args: object) -> None:
+        """Initializes error produced when Job completes with status "Failed" and the Job
+        supports producing failure results.
+
+        :param message: Error message.
+        :type message: str
+        :param failure_results: Failure results produced by the job.
+        :type failure_results: Any
+        """
+
         self._set_error_details(message, failure_results)
         super().__init__(message, *args)
 

--- a/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
+++ b/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
@@ -29,7 +29,7 @@ class MicrosoftElementsDftJob(Job):
         :type timeout_secs: float
         :raises: :class:`RuntimeError` if job execution failed.
         :raises: :class:`azure.quantum.job.JobFailedWithResultsError` if job execution failed,
-        but intermediate results could still be retrieved.
+                but intermediate results could still be retrieved.
         :return: Results dictionary with histogram shots, or raw results if not a json object.
         """
 

--- a/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
+++ b/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
@@ -29,7 +29,7 @@ class MicrosoftElementsDftJob(Job):
         :type timeout_secs: float
         :raises: :class:`RuntimeError` if job execution failed.
         :raises: :class:`azure.quantum.job.JobFailedWithResultsError` if job execution failed,
-                but intermediate results could still be retrieved.
+                but failure results could still be retrieved.
         :return: Results dictionary with histogram shots, or raw results if not a json object.
         """
 

--- a/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
+++ b/azure-quantum/azure/quantum/target/microsoft/elements/dft/job.py
@@ -27,7 +27,9 @@ class MicrosoftElementsDftJob(Job):
 
         :param timeout_secs: Timeout in seconds, defaults to 300
         :type timeout_secs: float
-        :raises: :class:`RuntimeError` Raises RuntimeError if job execution failed
+        :raises: :class:`RuntimeError` if job execution failed.
+        :raises: :class:`azure.quantum.job.JobFailedWithResultsError` if job execution failed,
+        but intermediate results could still be retrieved.
         :return: Results dictionary with histogram shots, or raw results if not a json object.
         """
 


### PR DESCRIPTION
- Added documentation for `JobFailedWithResultsError`
- Documented how to handle `JobFailedWithResultsError` thrown from `Job.get_results()`