### PR TITLE
fix: toggle DFT test run based on capabilities

### DIFF
--- a/azure-quantum/tests.live/Run.ps1
+++ b/azure-quantum/tests.live/Run.ps1
@@ -62,6 +62,9 @@ function PyTestMarkExpr() {
     }
     if ($AzureQuantumCapabilities -notcontains "submit.microsoft-qc") {
         $MarkExpr += " and not microsoft_qc"
+    }    
+    if ($AzureQuantumCapabilities -notcontains "submit.microsoft-elements") {
+        $MarkExpr += " and not microsoft_elements_dft"
     }
 
     return $MarkExpr


### PR DESCRIPTION
Run DFT E2E tests only if corresponding capability was set