### PR TITLE
Fix expired sas token on getting job result

### DIFF
--- a/azure-quantum/azure/quantum/job/base_job.py
+++ b/azure-quantum/azure/quantum/job/base_job.py
@@ -7,7 +7,8 @@ import logging
 import uuid
 
 from enum import Enum
-from urllib.parse import urlparse
+from datetime import datetime, timezone
+from urllib.parse import urlparse, parse_qs
 from typing import Any, Dict, Optional, TYPE_CHECKING
 from azure.storage.blob import BlobClient
 
@@ -368,8 +369,23 @@ class BaseJob(WorkspaceItem):
         :rtype: str
         """
         url = urlparse(blob_uri)
-        if url.query.find("se=") == -1:
-            # blob_uri does not contains SAS token,
+        query_params = parse_qs(url.query)
+        token_expire_query_param = query_params.get("se")
+
+        token_expire_time = None
+
+        if token_expire_query_param is not None:
+            token_expire_time_str = token_expire_query_param[0]
+
+            # Since python < 3.11 can not easily parse Z suffixed UTC timestamp and 
+            # assuming that the timestamp is always UTC, we replace that suffix with UTC offset.
+            token_expire_time = datetime.fromisoformat(
+                token_expire_time_str.replace('Z', '+00:00')
+            )
+
+        current_utc_time = datetime.now(tz=timezone.utc)
+        if token_expire_time is None or current_utc_time >= token_expire_time:
+            # blob_uri does not contains SAS token or it is expired,
             # get sas url from service
             blob_client = BlobClient.from_blob_url(
                 blob_uri

--- a/azure-quantum/tests/unit/test_workspace.py
+++ b/azure-quantum/tests/unit/test_workspace.py
@@ -349,6 +349,9 @@ class TestWorkspace(QuantumTestBase):
         ws = self.create_workspace()
         jobs = ws.list_jobs()
         self.assertIsInstance(jobs, list)
+        # Also get result of the job in order to verify that it can be obtained.
+        job = jobs[-1]
+        job.get_results()
 
     def test_workspace_user_agent_appid(self):
         app_id = "MyEnvVarAppId"


### PR DESCRIPTION
This PR add verification of the sas token's expiration time, to refresh it, if necessary.