### PR TITLE
fix: remove tagging from PR-build as it's not accessible for 3P contributors

### DIFF
--- a/.ado/ci.yml
+++ b/.ado/ci.yml
@@ -33,13 +33,6 @@ jobs:
       displayName: List installed packages
 
     - script: |
-        python set_version.py
-      env:
-        RELEASE_TYPE: "patch"
-        BUILD_TYPE: "dev"
-      displayName: Set "azure-quantum" package version
-
-    - script: |
         cd $(Build.SourcesDirectory)/azure-quantum
         python setup.py sdist --dist-dir=target/wheels
         python setup.py bdist_wheel --dist-dir=target/wheels


### PR DESCRIPTION
3P contributors get access issue in PR-builds
```
##[error]Access denied. AzureQuantum Build Service (ms-azurequantum) needs Edit build quality permissions for vstfs:///Build/Build/51475 in team project AzureQuantum to perform the action.
```
caused by tagging. Removing the PR-build tagging as not required.