### PR TITLE
update 23 qubits to 25

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/ionq.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/ionq.py
@@ -147,7 +147,7 @@ class IonQAriaQirBackend(IonQQirBackendBase):
                 "description": "IonQ Aria QPU on Azure Quantum",
                 "basis_gates": self._basis_gates(),
                 "memory": False,
-                "n_qubits": 23,
+                "n_qubits": 25,
                 "conditional": False,
                 "max_shots": 10000,
                 "max_experiments": 1,

--- a/azure-quantum/tests/unit/test_qiskit.py
+++ b/azure-quantum/tests/unit/test_qiskit.py
@@ -878,7 +878,7 @@ class TestQiskit(QuantumTestBase):
         config = backend.configuration()
         self.assertFalse(config.simulator)
         self.assertEqual(1, config.max_experiments)
-        self.assertEqual(23, config.num_qubits)
+        self.assertEqual(25, config.num_qubits)
         self.assertEqual("qir.v1", config.azure["content_type"])
         self.assertEqual("ionq", config.azure["provider_id"])
         self.assertEqual("qir.v1", config.azure["input_data_format"])


### PR DESCRIPTION
todo later - use backend calibration data to get `n_qubits`: https://github.com/qiskit-community/qiskit-ionq/blob/main/qiskit_ionq/helpers.py#L534-L562