### PR TITLE
Add support for h2-2 targets

### DIFF
--- a/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
+++ b/azure-quantum/azure/quantum/qiskit/backends/quantinuum.py
@@ -105,6 +105,7 @@ class QuantinuumSyntaxCheckerQirBackend(QuantinuumQirBackendBase):
         # Note: Target names on the same line are equivalent.
         "quantinuum.sim.h1-1sc",
         "quantinuum.sim.h2-1sc",
+        "quantinuum.sim.h2-2sc"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -142,6 +143,7 @@ class QuantinuumEmulatorQirBackend(QuantinuumQirBackendBase):
         # Note: Target names on the same line are equivalent.
         "quantinuum.sim.h1-1e",
         "quantinuum.sim.h2-1e",
+        "quantinuum.sim.h2-2e"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -179,6 +181,7 @@ class QuantinuumQPUQirBackend(QuantinuumQirBackendBase):
         # Note: Target names on the same line are equivalent.
         "quantinuum.qpu.h1-1",
         "quantinuum.qpu.h2-1",
+        "quantinuum.qpu.h2-2"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -253,6 +256,7 @@ class QuantinuumSyntaxCheckerBackend(QuantinuumBackend):
         # Note: Target names on the same line are equivalent.
         "quantinuum.sim.h1-1sc",
         "quantinuum.sim.h2-1sc",
+        "quantinuum.sim.h2-2sc"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -290,6 +294,7 @@ class QuantinuumEmulatorBackend(QuantinuumBackend):
         # Note: Target names on the same line are equivalent.
         "quantinuum.sim.h1-1e",
         "quantinuum.sim.h2-1e",
+        "quantinuum.sim.h2-2e"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):
@@ -327,6 +332,7 @@ class QuantinuumQPUBackend(QuantinuumBackend):
         # Note: Target names on the same line are equivalent.
         "quantinuum.qpu.h1-1",
         "quantinuum.qpu.h2-1",
+        "quantinuum.qpu.h2-2"
     )
 
     def __init__(self, name: str, provider: "AzureQuantumProvider", **kwargs):

--- a/azure-quantum/azure/quantum/target/quantinuum.py
+++ b/azure-quantum/azure/quantum/target/quantinuum.py
@@ -24,6 +24,9 @@ class Quantinuum(Target):
         "quantinuum.qpu.h2-1",
         "quantinuum.sim.h2-1sc",
         "quantinuum.sim.h2-1e",
+        "quantinuum.qpu.h2-2",
+        "quantinuum.sim.h2-2sc",
+        "quantinuum.sim.h2-2e",
     )
 
     _SHOTS_PARAM_NAME = "count"


### PR DESCRIPTION
The H2-2 QPU which is another instance of the H2 family of quantum computers. The H2-2E uses the error model specific to the H2-2 QPU. 