### PR TITLE
Check container_uri for container_name

### DIFF
--- a/azure-quantum/azure/quantum/job/base_job.py
+++ b/azure-quantum/azure/quantum/job/base_job.py
@@ -59,7 +59,14 @@ class BaseJob(WorkspaceItem):
     @property
     def container_name(self):
         """Job input/output data container name"""
-        return f"job-{self.id}"
+
+        if self._details.container_uri is None:
+            return  f"job-{self.id}"
+        else:
+            container_uri = self._details.container_uri
+        path = urlparse(container_uri).path
+        container_name = path.split("/")[1]
+        return container_name
 
     @classmethod
     def from_input_data(
@@ -323,7 +330,10 @@ class BaseJob(WorkspaceItem):
 
         # Use Job's default container if not specified
         if container_uri is None:
-            container_uri = self.workspace.get_container_uri(job_id=self.id)
+            if self._details.container_uri is None:
+                container_uri = self.workspace.get_container_uri(job_id=self.id)
+            else:
+                container_uri = self._details.container_uri
 
         uploaded_blob_uri = self.upload_input_data(
             container_uri = container_uri,
@@ -353,7 +363,10 @@ class BaseJob(WorkspaceItem):
 
         # Use Job's default container if not specified
         if container_uri is None:
-            container_uri = self.workspace.get_container_uri(job_id=self.id)
+            if self._details.container_uri is None:
+                container_uri = self.workspace.get_container_uri(job_id=self.id)
+            else:
+                container_uri = self._details.container_uri
         
         container_client = ContainerClient.from_container_url(container_uri)
         blob_client = container_client.get_blob_client(name)


### PR DESCRIPTION
One of the chemistry users reported a [bug](https://dev.azure.com/ms-azurequantum/AzureQuantum/_workitems/edit/34158), where they changed the name of the container that the job uses during the run. This appears to work fine for submitting and running the job, but they experienced errors when trying to download the data using download attachment function where it would use the default name of the container instead. This PR fixes this bug by first checking whether the container uri is instantiated and if so, then parsing the container name from it. 