### PR TITLE
Remove driver check for ADFT

### DIFF
--- a/azure-quantum/azure/quantum/target/microsoft/elements/dft/target.py
+++ b/azure-quantum/azure/quantum/target/microsoft/elements/dft/target.py
@@ -240,10 +240,6 @@ class MicrosoftElementsDft(Target):
         # Check Model params
         self._check_dict_for_required_keys(input_params['model'], 'input_params["model"]', ['method', 'basis'])
 
-        supported_drivers = ['energy', 'gradient', 'hessian', 'go', 'bomd']
-        if input_params['driver'] not in supported_drivers:
-            raise ValueError(f"Driver ({input_params['driver']}) is not supported. Please use one of {supported_drivers}.")
-
     
     @classmethod
     def _check_dict_for_required_keys(self, input_params: dict, dict_name: str, required_keys: list[str]):


### PR DESCRIPTION
In the bug bash today, we found a bug where the chemistry team added a new driver (polarizability) but we couldn't submit a job because the SDK checks for supported drivers. Based on discussions with David, it sounds like they plan on adding a lot more drivers in the future so I think it is better to remove the check on the SDK side.  Regardless, this parameter is validated on the API side. This was done to fail early but now it seems like it will inhibit the dev process more than help. 