### PR TITLE
Fix provider id for targets with non-standard provider ids

### DIFF
--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -117,7 +117,7 @@ avg. queue time={self._average_queue_time} s, {self._current_availability}>"
 
     @classmethod
     def from_target_status(
-        cls, workspace: "Workspace", status: TargetStatus, **kwargs
+        cls, workspace: "Workspace", provider_id: str, status: TargetStatus, **kwargs
     ):
         """Create a Target instance from a given workspace and target status.
 
@@ -131,6 +131,7 @@ avg. queue time={self._average_queue_time} s, {self._current_availability}>"
         return cls(
             workspace=workspace,
             name=status.id,
+            provider_id=provider_id,
             average_queue_time=status.average_queue_time,
             current_availability=status.current_availability,
             **kwargs

--- a/azure-quantum/azure/quantum/target/target_factory.py
+++ b/azure-quantum/azure/quantum/target/target_factory.py
@@ -68,10 +68,6 @@ class TargetFactory:
         if provider_id.lower() in self._default_targets:
             return self._default_targets[provider_id.lower()]
  
-        warnings.warn(
-            f"No default target specified for provider {provider_id}. \
-Please check the provider name and try again or create an issue here: \
-https://github.com/microsoft/qdk-python/issues.")
         return Target
 
     def create_target(

--- a/azure-quantum/azure/quantum/target/target_factory.py
+++ b/azure-quantum/azure/quantum/target/target_factory.py
@@ -105,7 +105,7 @@ https://github.com/microsoft/qdk-python/issues.")
     ):
         cls = self._target_cls(provider_id, status.id)
         if hasattr(cls, "from_target_status"):
-            return cls.from_target_status(self._workspace, status, **kwargs)
+            return cls.from_target_status(self._workspace, provider_id, status, **kwargs)
         elif cls is not None:
             return cls(name=status.id, **kwargs)
 


### PR DESCRIPTION
This fixes an issue where provider id is not being pulled correctly from provider status.

This also removes the warning message when no default target class is defined, since for dynamic providers, this is no longer required.

