### PR TITLE
Add shots param handling for base Target class

### DIFF
--- a/azure-quantum/azure/quantum/target/target.py
+++ b/azure-quantum/azure/quantum/target/target.py
@@ -55,7 +55,7 @@ class Target(abc.ABC, SessionHost):
 
     # Name of the provider's input parameter which specifies number of shots for a submitted job.
     # If None, target will not pass this input parameter. 
-    _SHOTS_PARAM_NAME = None
+    _SHOTS_PARAM_NAME = "shots"
 
     def __init__(
         self,


### PR DESCRIPTION
If using a target that does not have a dedicated provider class, TargetFactory falls back to the base Target class.

While this works for most Q# and QIR settings, it does not handle "shots" parameter, so it is not set on the input_param dictionary.

This can cause invisible or unexpected failures if target expects shots to be provided.

Adding default behavior to still handle "shots" parameter if it is passed into job.submit()